### PR TITLE
Paralelism fixes vol.2 - MultipleClusterOperatorsST, KafkaRebalance readiness, tags

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaRebalanceResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaRebalanceResource.java
@@ -10,8 +10,10 @@ import io.fabric8.kubernetes.client.dsl.Resource;
 import io.strimzi.api.kafka.Crds;
 import io.strimzi.api.kafka.KafkaRebalanceList;
 import io.strimzi.api.kafka.model.KafkaRebalance;
+import io.strimzi.api.kafka.model.balancing.KafkaRebalanceState;
 import io.strimzi.systemtest.resources.ResourceManager;
 import io.strimzi.systemtest.resources.ResourceType;
+import io.strimzi.systemtest.utils.kafkaUtils.KafkaRebalanceUtils;
 
 import java.util.function.Consumer;
 
@@ -39,7 +41,7 @@ public class KafkaRebalanceResource implements ResourceType<KafkaRebalance> {
     }
     @Override
     public boolean isReady(KafkaRebalance resource) {
-        return resource != null;
+        return KafkaRebalanceUtils.waitForKafkaRebalanceCustomResourceState(resource.getMetadata().getName(), KafkaRebalanceState.PendingProposal);
     }
     @Override
     public void refreshResource(KafkaRebalance existing, KafkaRebalance newResource) {

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaRebalanceUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaRebalanceUtils.java
@@ -46,9 +46,9 @@ public class KafkaRebalanceUtils {
         }
     }
 
-    public static void waitForKafkaRebalanceCustomResourceState(String resourceName, KafkaRebalanceState state) {
+    public static boolean waitForKafkaRebalanceCustomResourceState(String resourceName, KafkaRebalanceState state) {
         KafkaRebalance kafkaRebalance = KafkaRebalanceResource.kafkaRebalanceClient().inNamespace(kubeClient().getNamespace()).withName(resourceName).get();
-        ResourceManager.waitForResourceStatus(KafkaRebalanceResource.kafkaRebalanceClient(), kafkaRebalance, state, ResourceOperation.getTimeoutForKafkaRebalanceState(state));
+        return ResourceManager.waitForResourceStatus(KafkaRebalanceResource.kafkaRebalanceClient(), kafkaRebalance, state, ResourceOperation.getTimeoutForKafkaRebalanceState(state));
     }
 
     public static String annotateKafkaRebalanceResource(String resourceName, KafkaRebalanceAnnotation annotation) {

--- a/systemtest/src/test/java/io/strimzi/systemtest/cruisecontrol/CruiseControlIsolatedST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/cruisecontrol/CruiseControlIsolatedST.java
@@ -14,7 +14,7 @@ import io.strimzi.systemtest.AbstractST;
 import io.strimzi.api.kafka.model.balancing.KafkaRebalanceAnnotation;
 import io.strimzi.api.kafka.model.balancing.KafkaRebalanceState;
 import io.strimzi.systemtest.Constants;
-import io.strimzi.systemtest.annotations.ParallelTest;
+import io.strimzi.systemtest.annotations.IsolatedTest;
 import io.strimzi.systemtest.resources.crd.KafkaRebalanceResource;
 import io.strimzi.systemtest.resources.crd.KafkaResource;
 import io.strimzi.systemtest.resources.crd.KafkaTopicResource;
@@ -58,7 +58,7 @@ public class CruiseControlIsolatedST extends AbstractST {
     private static final String CRUISE_CONTROL_MODEL_TRAINING_SAMPLES_TOPIC = "strimzi.cruisecontrol.modeltrainingsamples"; // partitions 32 , rf - 2
     private static final String CRUISE_CONTROL_PARTITION_METRICS_SAMPLES_TOPIC = "strimzi.cruisecontrol.partitionmetricsamples"; // partitions 32 , rf - 2
 
-    @ParallelTest
+    @IsolatedTest
     void testAutoCreationOfCruiseControlTopics(ExtensionContext extensionContext) {
         String clusterName = mapTestWithClusterNames.get(extensionContext.getDisplayName());
 
@@ -97,10 +97,10 @@ public class CruiseControlIsolatedST extends AbstractST {
         assertThat(partitionMetricsTopic.getReplicas(), is(2));
     }
 
-    @ParallelTest
+    @IsolatedTest
     @Tag(ACCEPTANCE)
     void testCruiseControlWithRebalanceResource(ExtensionContext extensionContext) {
-        String clusterName = mapTestWithClusterNames.get(extensionContext.getDisplayName());
+        String clusterName = "what-about-this";
 
         resourceManager.createResource(extensionContext, KafkaTemplates.kafkaWithCruiseControl(clusterName, 3, 3).build());
         resourceManager.createResource(extensionContext, KafkaRebalanceTemplates.kafkaRebalance(clusterName).build());
@@ -108,7 +108,7 @@ public class CruiseControlIsolatedST extends AbstractST {
         KafkaRebalanceUtils.doRebalancingProcess(clusterName);
     }
 
-    @ParallelTest
+    @IsolatedTest
     void testCruiseControlWithSingleNodeKafka(ExtensionContext extensionContext) {
         String clusterName = mapTestWithClusterNames.get(extensionContext.getDisplayName());
 
@@ -133,7 +133,7 @@ public class CruiseControlIsolatedST extends AbstractST {
         assertThat(kafkaStatus.getConditions().get(0).getMessage(), is(not(errMessage)));
     }
 
-    @ParallelTest
+    @IsolatedTest
     void testCruiseControlTopicExclusion(ExtensionContext extensionContext) {
         String clusterName = mapTestWithClusterNames.get(extensionContext.getDisplayName());
 
@@ -164,7 +164,7 @@ public class CruiseControlIsolatedST extends AbstractST {
         KafkaRebalanceUtils.waitForKafkaRebalanceCustomResourceState(clusterName, KafkaRebalanceState.Ready);
     }
 
-    @ParallelTest
+    @IsolatedTest
     void testCruiseControlReplicaMovementStrategy(ExtensionContext extensionContext) {
         String clusterName = mapTestWithClusterNames.get(extensionContext.getDisplayName());
         String kafkaClientsName = mapTestWithKafkaClientNames.get(extensionContext.getDisplayName());
@@ -205,7 +205,7 @@ public class CruiseControlIsolatedST extends AbstractST {
         assertThat(ccConfFileContent, containsString(newReplicaMovementStrategies));
     }
 
-    @ParallelTest
+    @IsolatedTest
     void testHostAliases(ExtensionContext extensionContext) {
         String clusterName = mapTestWithClusterNames.get(extensionContext.getDisplayName());
 
@@ -236,7 +236,7 @@ public class CruiseControlIsolatedST extends AbstractST {
     }
 
     @BeforeAll
-    void setup(ExtensionContext extensionContext) throws Exception {
+    void setup(ExtensionContext extensionContext) {
         installClusterOperator(extensionContext, NAMESPACE);
     }
 }

--- a/systemtest/src/test/java/io/strimzi/systemtest/kafka/KafkaST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/kafka/KafkaST.java
@@ -42,7 +42,6 @@ import io.strimzi.systemtest.Constants;
 import io.strimzi.systemtest.Environment;
 import io.strimzi.systemtest.annotations.IsolatedTest;
 import io.strimzi.systemtest.annotations.OpenShiftOnly;
-import io.strimzi.systemtest.annotations.ParallelTest;
 import io.strimzi.systemtest.cli.KafkaCmdClient;
 import io.strimzi.systemtest.kafkaclients.internalClients.InternalKafkaClient;
 import io.strimzi.systemtest.resources.ResourceManager;

--- a/systemtest/src/test/java/io/strimzi/systemtest/kafka/KafkaST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/kafka/KafkaST.java
@@ -40,6 +40,7 @@ import io.strimzi.operator.common.model.Labels;
 import io.strimzi.systemtest.AbstractST;
 import io.strimzi.systemtest.Constants;
 import io.strimzi.systemtest.Environment;
+import io.strimzi.systemtest.annotations.IsolatedTest;
 import io.strimzi.systemtest.annotations.OpenShiftOnly;
 import io.strimzi.systemtest.annotations.ParallelTest;
 import io.strimzi.systemtest.cli.KafkaCmdClient;
@@ -111,7 +112,7 @@ class KafkaST extends AbstractST {
     public static final String NAMESPACE = "kafka-cluster-test";
     private static final String OPENSHIFT_CLUSTER_NAME = "openshift-my-cluster";
 
-    @ParallelTest
+    @IsolatedTest
     @OpenShiftOnly
     void testDeployKafkaClusterViaTemplate(ExtensionContext extensionContext) {
         cluster.createCustomResources(TEMPLATE_PATH);
@@ -142,7 +143,7 @@ class KafkaST extends AbstractST {
         DeploymentUtils.waitForDeploymentDeletion(KafkaResources.entityOperatorDeploymentName(OPENSHIFT_CLUSTER_NAME));
     }
 
-    @ParallelTest
+    @IsolatedTest
     void testEODeletion(ExtensionContext extensionContext) {
         String clusterName = mapTestWithClusterNames.get(extensionContext.getDisplayName());
 
@@ -169,7 +170,7 @@ class KafkaST extends AbstractST {
         LOGGER.info("Entity operator was deleted");
     }
 
-    @ParallelTest
+    @IsolatedTest
     @SuppressWarnings({"checkstyle:MethodLength", "checkstyle:JavaNCSS"})
     void testCustomAndUpdatedValues(ExtensionContext extensionContext) {
         String clusterName = mapTestWithClusterNames.get(extensionContext.getDisplayName());
@@ -452,7 +453,7 @@ class KafkaST extends AbstractST {
         checkSpecificVariablesInContainer(KafkaResources.entityOperatorDeploymentName(clusterName), "tls-sidecar", envVarUpdated);
     }
 
-    @ParallelTest
+    @IsolatedTest
     void testJvmAndResources(ExtensionContext extensionContext) {
         String clusterName = mapTestWithClusterNames.get(extensionContext.getDisplayName());
 
@@ -585,7 +586,7 @@ class KafkaST extends AbstractST {
         DeploymentUtils.waitForNoRollingUpdate(eoDepName, eoPods);
     }
 
-    @ParallelTest
+    @IsolatedTest
     void testForTopicOperator(ExtensionContext extensionContext) throws InterruptedException {
         String clusterName = mapTestWithClusterNames.get(extensionContext.getDisplayName());
 
@@ -645,7 +646,7 @@ class KafkaST extends AbstractST {
         assertThat(topics, not(hasItems(cliTopicName)));
     }
 
-    @ParallelTest
+    @IsolatedTest
     void testRemoveTopicOperatorFromEntityOperator(ExtensionContext extensionContext) {
         String clusterName = mapTestWithClusterNames.get(extensionContext.getDisplayName());
 
@@ -687,7 +688,7 @@ class KafkaST extends AbstractST {
         });
     }
 
-    @ParallelTest
+    @IsolatedTest
     void testRemoveUserOperatorFromEntityOperator(ExtensionContext extensionContext) {
         String clusterName = mapTestWithClusterNames.get(extensionContext.getDisplayName());
 
@@ -735,7 +736,7 @@ class KafkaST extends AbstractST {
         assertNoCoErrorsLogged(timeMeasuringSystem.getDurationInSeconds(extensionContext.getRequiredTestClass().getName(), extensionContext.getDisplayName(), operationId));
     }
 
-    @ParallelTest
+    @IsolatedTest
     void testRemoveUserAndTopicOperatorsFromEntityOperator(ExtensionContext extensionContext) {
         String clusterName = mapTestWithClusterNames.get(extensionContext.getDisplayName());
 
@@ -777,7 +778,7 @@ class KafkaST extends AbstractST {
         assertNoCoErrorsLogged(timeMeasuringSystem.getDurationInSeconds(extensionContext.getRequiredTestClass().getName(), extensionContext.getDisplayName(), operationId));
     }
 
-    @ParallelTest
+    @IsolatedTest
     void testEntityOperatorWithoutTopicOperator(ExtensionContext extensionContext) {
         String clusterName = mapTestWithClusterNames.get(extensionContext.getDisplayName());
 
@@ -805,7 +806,7 @@ class KafkaST extends AbstractST {
         });
     }
 
-    @ParallelTest
+    @IsolatedTest
     void testEntityOperatorWithoutUserOperator(ExtensionContext extensionContext) {
         String clusterName = mapTestWithClusterNames.get(extensionContext.getDisplayName());
 
@@ -831,7 +832,7 @@ class KafkaST extends AbstractST {
         });
     }
 
-    @ParallelTest
+    @IsolatedTest
     void testEntityOperatorWithoutUserAndTopicOperators(ExtensionContext extensionContext) {
         String clusterName = mapTestWithClusterNames.get(extensionContext.getDisplayName());
 
@@ -851,7 +852,7 @@ class KafkaST extends AbstractST {
         assertThat("EO should not be deployed", kubeClient().listPodsByPrefixInName(KafkaResources.entityOperatorDeploymentName(clusterName)).size(), is(0));
     }
 
-    @ParallelTest
+    @IsolatedTest
     void testTopicWithoutLabels(ExtensionContext extensionContext) {
         String clusterName = mapTestWithClusterNames.get(extensionContext.getDisplayName());
 
@@ -884,7 +885,7 @@ class KafkaST extends AbstractST {
         assertThat(topics, not(hasItems("topic-without-labels")));
     }
 
-    @ParallelTest
+    @IsolatedTest
     @Tag(REGRESSION)
     void testKafkaJBODDeleteClaimsTrueFalse(ExtensionContext extensionContext) {
         String clusterName = mapTestWithClusterNames.get(extensionContext.getDisplayName());
@@ -910,7 +911,7 @@ class KafkaST extends AbstractST {
         verifyPVCDeletion(clusterName, kafkaReplicas, jbodStorage);
     }
 
-    @ParallelTest
+    @IsolatedTest
     void testKafkaJBODDeleteClaimsTrue(ExtensionContext extensionContext) {
         String clusterName = mapTestWithClusterNames.get(extensionContext.getDisplayName());
 
@@ -935,7 +936,7 @@ class KafkaST extends AbstractST {
         verifyPVCDeletion(clusterName, kafkaReplicas, jbodStorage);
     }
 
-    @ParallelTest
+    @IsolatedTest
     void testKafkaJBODDeleteClaimsFalse(ExtensionContext extensionContext) {
         String clusterName = mapTestWithClusterNames.get(extensionContext.getDisplayName());
 
@@ -960,7 +961,7 @@ class KafkaST extends AbstractST {
         verifyPVCDeletion(clusterName, kafkaReplicas, jbodStorage);
     }
 
-    @ParallelTest
+    @IsolatedTest
     @Tag(INTERNAL_CLIENTS_USED)
     void testPersistentStorageSize(ExtensionContext extensionContext) {
         String clusterName = mapTestWithClusterNames.get(extensionContext.getDisplayName());
@@ -1014,7 +1015,7 @@ class KafkaST extends AbstractST {
         );
     }
 
-    @ParallelTest
+    @IsolatedTest
     @Tag(LOADBALANCER_SUPPORTED)
     void testRegenerateCertExternalAddressChange(ExtensionContext extensionContext) {
         String clusterName = mapTestWithClusterNames.get(extensionContext.getDisplayName());
@@ -1057,7 +1058,7 @@ class KafkaST extends AbstractST {
         });
     }
 
-    @ParallelTest
+    @IsolatedTest
     @Tag(INTERNAL_CLIENTS_USED)
     void testLabelModificationDoesNotBreakCluster(ExtensionContext extensionContext) {
         String clusterName = mapTestWithClusterNames.get(extensionContext.getDisplayName());
@@ -1207,7 +1208,7 @@ class KafkaST extends AbstractST {
         );
     }
 
-    @ParallelTest
+    @IsolatedTest
     @Tag(INTERNAL_CLIENTS_USED)
     void testAppDomainLabels(ExtensionContext extensionContext) {
         String clusterName = mapTestWithClusterNames.get(extensionContext.getDisplayName());
@@ -1293,7 +1294,7 @@ class KafkaST extends AbstractST {
         );
     }
 
-    @ParallelTest
+    @IsolatedTest
     void testUOListeningOnlyUsersInSameCluster(ExtensionContext extensionContext) {
         String clusterName = mapTestWithClusterNames.get(extensionContext.getDisplayName());
         String userName = mapTestWithTestUsers.get(extensionContext.getDisplayName());
@@ -1320,7 +1321,7 @@ class KafkaST extends AbstractST {
         assertThat(kafkaUserResource, containsString(Labels.STRIMZI_CLUSTER_LABEL + ": " + firstClusterName));
     }
 
-    @ParallelTest
+    @IsolatedTest
     @Tag(INTERNAL_CLIENTS_USED)
     void testMessagesAreStoredInDisk(ExtensionContext extensionContext) {
         String clusterName = mapTestWithClusterNames.get(extensionContext.getDisplayName());
@@ -1389,7 +1390,7 @@ class KafkaST extends AbstractST {
         assertThat("Topic has no data", topicData, notNullValue());
     }
 
-    @ParallelTest
+    @IsolatedTest
     @Tag(INTERNAL_CLIENTS_USED)
     void testConsumerOffsetFiles(ExtensionContext extensionContext) {
         String clusterName = mapTestWithClusterNames.get(extensionContext.getDisplayName());
@@ -1453,7 +1454,7 @@ class KafkaST extends AbstractST {
     }
 
 
-    @ParallelTest
+    @IsolatedTest
     void testLabelsAndAnnotationForPVC(ExtensionContext extensionContext) {
         String clusterName = mapTestWithClusterNames.get(extensionContext.getDisplayName());
 
@@ -1561,7 +1562,7 @@ class KafkaST extends AbstractST {
         }
     }
 
-    @ParallelTest
+    @IsolatedTest
     void testKafkaOffsetsReplicationFactorHigherThanReplicas(ExtensionContext extensionContext) {
         String clusterName = mapTestWithClusterNames.get(extensionContext.getDisplayName());
 
@@ -1578,7 +1579,7 @@ class KafkaST extends AbstractST {
             "Kafka configuration option .* should be set to " + 3 + " or less because 'spec.kafka.replicas' is " + 3);
     }
 
-    @ParallelTest
+    @IsolatedTest
     void testHostAliases(ExtensionContext extensionContext) {
         String clusterName = mapTestWithClusterNames.get(extensionContext.getDisplayName());
 
@@ -1618,7 +1619,7 @@ class KafkaST extends AbstractST {
         }
     }
 
-    @ParallelTest
+    @IsolatedTest
     @Tag(INTERNAL_CLIENTS_USED)
     void testReadOnlyRootFileSystem(ExtensionContext extensionContext) {
         String clusterName = mapTestWithClusterNames.get(extensionContext.getDisplayName());

--- a/systemtest/src/test/java/io/strimzi/systemtest/kafka/dynamicconfiguration/DynamicConfigurationIsolatedST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/kafka/dynamicconfiguration/DynamicConfigurationIsolatedST.java
@@ -13,7 +13,6 @@ import io.strimzi.systemtest.AbstractST;
 import io.strimzi.systemtest.Constants;
 import io.strimzi.systemtest.Environment;
 import io.strimzi.systemtest.annotations.IsolatedTest;
-import io.strimzi.systemtest.annotations.ParallelTest;
 import io.strimzi.systemtest.kafkaclients.externalClients.BasicExternalKafkaClient;
 import io.strimzi.systemtest.resources.crd.KafkaResource;
 import io.strimzi.systemtest.templates.crd.KafkaTemplates;

--- a/systemtest/src/test/java/io/strimzi/systemtest/kafka/dynamicconfiguration/DynamicConfigurationIsolatedST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/kafka/dynamicconfiguration/DynamicConfigurationIsolatedST.java
@@ -12,6 +12,7 @@ import io.strimzi.api.kafka.model.listener.arraylistener.KafkaListenerType;
 import io.strimzi.systemtest.AbstractST;
 import io.strimzi.systemtest.Constants;
 import io.strimzi.systemtest.Environment;
+import io.strimzi.systemtest.annotations.IsolatedTest;
 import io.strimzi.systemtest.annotations.ParallelTest;
 import io.strimzi.systemtest.kafkaclients.externalClients.BasicExternalKafkaClient;
 import io.strimzi.systemtest.resources.crd.KafkaResource;
@@ -63,7 +64,7 @@ public class DynamicConfigurationIsolatedST extends AbstractST {
 
     private Map<String, Object> kafkaConfig;
 
-    @ParallelTest
+    @IsolatedTest
     void testSimpleDynamicConfiguration(ExtensionContext extensionContext) {
         String clusterName = mapTestWithClusterNames.get(extensionContext.getDisplayName());
         Map<String, Object> deepCopyOfShardKafkaConfig = kafkaConfig.entrySet().stream()
@@ -102,7 +103,7 @@ public class DynamicConfigurationIsolatedST extends AbstractST {
 
     @Tag(NODEPORT_SUPPORTED)
     @Tag(ROLLING_UPDATE)
-    @ParallelTest
+    @IsolatedTest
     void testUpdateToExternalListenerCausesRollingRestart(ExtensionContext extensionContext) {
         String clusterName = mapTestWithClusterNames.get(extensionContext.getDisplayName());
         Map<String, Object> deepCopyOfShardKafkaConfig = kafkaConfig.entrySet().stream()
@@ -220,7 +221,7 @@ public class DynamicConfigurationIsolatedST extends AbstractST {
         assertThat(kafkaConfigurationFromPod, containsString("unclean.leader.election.enable=" + false));
     }
 
-    @ParallelTest
+    @IsolatedTest
     @Tag(NODEPORT_SUPPORTED)
     @Tag(EXTERNAL_CLIENTS_USED)
     @Tag(ROLLING_UPDATE)

--- a/systemtest/src/test/java/io/strimzi/systemtest/operators/MultipleClusterOperatorsST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/operators/MultipleClusterOperatorsST.java
@@ -79,7 +79,7 @@ public class MultipleClusterOperatorsST extends AbstractST {
         cluster.setNamespace(DEFAULT_NAMESPACE);
 
         LOGGER.info("Deploying Kafka without CR selector");
-        resourceManager.createResource(extensionContext, KafkaTemplates.kafkaEphemeral(clusterName, 3, 3).build());
+        resourceManager.createResource(extensionContext, false, KafkaTemplates.kafkaEphemeral(clusterName, 3, 3).build());
 
         // checking that no pods with prefix 'clusterName' will be created in some time
         PodUtils.waitUntilPodStabilityReplicasCount(clusterName, 0);
@@ -190,7 +190,7 @@ public class MultipleClusterOperatorsST extends AbstractST {
 
         LOGGER.info("Creating {} in {} namespace", coName, coNamespace);
 
-        resourceManager.createResource(extensionContext, BundleResource.clusterOperator(namespace, coNamespace, Constants.RECONCILIATION_INTERVAL)
+        resourceManager.createResource(extensionContext, BundleResource.clusterOperator(coNamespace, namespace, Constants.RECONCILIATION_INTERVAL)
             .editOrNewMetadata()
                 .withName(coName)
             .endMetadata()

--- a/systemtest/src/test/java/io/strimzi/systemtest/specific/SpecificST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/specific/SpecificST.java
@@ -46,7 +46,6 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Tag;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtensionContext;
 
 import java.util.Collections;


### PR DESCRIPTION
### Description

Fixes for MutlipleClusterOperatorsST#testMultipleCOsInDifferentNamespaces, other one is still failing on some error in KR, which should have some further investigation. I also change the way how we are waiting for KR readiness, replaced @ParallelTest with @IsolatedTest in cases where Kafka cluster is created for each testcase.

